### PR TITLE
replace course menu text

### DIFF
--- a/src/course.ts
+++ b/src/course.ts
@@ -3,6 +3,7 @@
 // fix or enhance the course experience.
 import injectOnlineLink from "./course/inject_online_link";
 import injectCourseMenuButton from "./course/inject_course_menu_button";
+import changeCourseMenuText from "./course/change_course_menu_text";
 import overrideNavButtons from "./course/override_nav_buttons";
 import fixFileDownloads from "./course/fix_file_downloads";
 import fixTrailingSlashes from "./course/fix_trailing_slashes";
@@ -15,6 +16,7 @@ function init() {
   addUnloadListener();
   injectOnlineLink();
   injectCourseMenuButton();
+  changeCourseMenuText();
   overrideNavButtons();
   fixFileDownloads();
   fixTrailingSlashes();

--- a/src/course/change_course_menu_text.ts
+++ b/src/course/change_course_menu_text.ts
@@ -1,0 +1,17 @@
+// Replace the text in the header of the mobile course menu.
+// It's a little awkward to select because the heading contains text
+// and DOM nodes
+export default function changeCourseMenuText() {
+  const heading = document.querySelector<HTMLElement>("#mobile-course-nav h3");
+  if (!heading) return;
+
+  const textNode = heading.firstChild;
+  if (
+    textNode &&
+    textNode.nodeType === Node.TEXT_NODE &&
+    // the text node contains newlines and spaces
+    textNode.textContent?.trim() === "Browse Course Material"
+  ) {
+    textNode.textContent = "Course Menu";
+  }
+}


### PR DESCRIPTION
The mobile course menu will say 'Course Menu' instead of 'Browse Course Material'