### PR TITLE
re-enable resource link replacement. Still unstyled

### DIFF
--- a/src/course.ts
+++ b/src/course.ts
@@ -7,7 +7,7 @@ import changeCourseMenuText from "./course/change_course_menu_text";
 import addManageVideosButton from "./course/add_manage_videos_button";
 import overrideNavButtons from "./course/override_nav_buttons";
 import fixFileDownloads from "./course/fix_file_downloads";
-// import replaceResourceItems from "./course/replace_resource_items";
+import replaceResourceItems from "./course/replace_resource_items";
 import fixTrailingSlashes from "./course/fix_trailing_slashes";
 import renderPdfs from "./course/render_pdfs";
 import injectOfflineVideos from "./course/inject_offline_videos";
@@ -20,7 +20,7 @@ function init() {
   changeCourseMenuText();
   addManageVideosButton();
   overrideNavButtons();
-  // replaceResourceItems();
+  replaceResourceItems();
   fixFileDownloads();
   fixTrailingSlashes();
   renderPdfs();

--- a/src/course/replace_resource_items.ts
+++ b/src/course/replace_resource_items.ts
@@ -1,6 +1,5 @@
 // Replaces the resources items with our own version that looks consistent with
 // the OCW app, and clarifies the download language.
-// NOTE this is unused and incomplete.
 export default function replaceResourceItems() {
   document.querySelectorAll(".resource-item").forEach((item) => {
     const name = item
@@ -22,8 +21,8 @@ export default function replaceResourceItems() {
     template.innerHTML =
       "<div class='resource-item'>" +
       `<a href="${path}" class="resource-link">` +
-      `<span class="resource-name">${name}</span>` +
-      `<span class="resource-type">${type}</span>` +
+      `<span class="resource-name">${name}</span> ` +
+      `<span class="resource-type">${type}</span> ` +
       (size ? `<span class="resource-size">${size}</span>` : "") +
       "</a></div>";
 


### PR DESCRIPTION
@ThinkBrandonThink This needs styling. Currently it's finding the resource links, extracting the relevant info, and replacing it will very simple HTML. let me know if you need help with this. Styles will need to go in dist/course-styles.css

<img width="830" height="183" alt="image" src="https://github.com/user-attachments/assets/d7579bb5-14cb-48c6-98e8-76849dcc731f" />


closes #56 