### PR TITLE
Renaming things

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -576,8 +576,6 @@ header img {
   background-color: #f6f7f9;
 }
 .mobile-nav__drawer-bottom {
-  display: flex;
-  align-items: center;
   padding: 1.6rem 2.4rem;
   margin: 0;
   font-size: 1.2rem;

--- a/src/app/storage_usage.tsx
+++ b/src/app/storage_usage.tsx
@@ -16,7 +16,7 @@ export default function StorageUsage() {
 
   return (
     <>
-      Local Storage Used:&nbsp;
+      Web Browser Local Storage Used:&nbsp;
       <span>
         {storage.usedPercent}% ({storage.usedSpace} / {storage.totalSpace})
       </span>

--- a/src/app/video_downloader.ts
+++ b/src/app/video_downloader.ts
@@ -105,7 +105,9 @@ export default class VideoDownloader {
       const wasAborted = e instanceof DOMException && e.name === "AbortError";
       if (wasAborted) return;
 
-      let errorMessage = "An error occurred";
+      // We're checking for storage errors, any other error is almost certainly a network issue
+      let errorMessage =
+        "An error occurred. Please check your network connection.";
       const outOfSpace = e instanceof Error && e.name === "QuotaExceededError";
       if (outOfSpace) {
         errorMessage = "Not enough space to download this video.";


### PR DESCRIPTION
closes #76 and closes #77

Renames 'local storage' to 'web browser local storage' and makes the video download error more verbose. Both of these are little squishy in places now.

Footer in mobile nav looks like this now:
<img width="313" height="164" alt="image" src="https://github.com/user-attachments/assets/d2d7148a-0ef4-45e0-9bd5-29a8e30e38c1" />

The video errors looks like this at some sizes. At larger sizes, it looks fine, and at smaller sizes it collapses to be underneath everything, but this is an in-between spot.
<img width="647" height="169" alt="image" src="https://github.com/user-attachments/assets/0f7ba278-13f3-4bf9-8f0c-ee66a3785449" />
