### PR TITLE
add an icon after external links in the course

### DIFF
--- a/src/course-styles.css
+++ b/src/course-styles.css
@@ -77,9 +77,15 @@ resource-item {
 resource-item + resource-item {
   border-top: none;
 }
-#course-main-content a[href^="https://"]:after,
-#course-main-content a[href^="http://"]:after
-{
-  content: "\21D7";
-  font-size: 150%;
+
+a .external-link-icon {
+  margin-left: 0.2em;
+  display: inline-block;
+  text-decoration: none;
+
+  svg {
+    fill: currentColor;
+    width: 1em;
+    height: 1em;
+  }
 }

--- a/src/course/make_outside_links_open_in_new_tab.ts
+++ b/src/course/make_outside_links_open_in_new_tab.ts
@@ -1,8 +1,26 @@
+// Make external links open in a new tab and adds an icon to text-only links to
+// make that more obvious.
 export default function makeOutsideLinksOpenInNewTab() {
   document.querySelectorAll("a").forEach((link) => {
-    if (link.host !== window.location.host) {
-      link.setAttribute("target", "_blank");
-      link.setAttribute("rel", "noopener noreferrer");
-    }
+    if (link.host === window.location.host) return;
+
+    link.setAttribute("target", "_blank");
+    link.setAttribute("rel", "noopener noreferrer");
+
+    if (link.querySelector("img, svg, video")) return;
+
+    const span = document.createElement("span");
+    span.classList.add("external-link-icon");
+    span.innerHTML = html;
+    link.appendChild(span);
   });
 }
+
+const html = `
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 -960 960 960"
+  >
+    <path d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h240q17 0 28.5 11.5T480-800q0 17-11.5 28.5T440-760H200v560h560v-240q0-17 11.5-28.5T800-480q17 0 28.5 11.5T840-440v240q0 33-23.5 56.5T760-120H200Zm560-584L416-360q-11 11-28 11t-28-11q-11-11-11-28t11-28l344-344H600q-17 0-28.5-11.5T560-800q0-17 11.5-28.5T600-840h200q17 0 28.5 11.5T840-800v200q0 17-11.5 28.5T800-560q-17 0-28.5-11.5T760-600v-104Z" />
+  </svg>
+`;


### PR DESCRIPTION
This is an experiment to add an icon to links within courses indicating that they lead to external URLs. Currently we're just adding a unicode character as a CSS pseudo element. I'm limiting it to the main course content div. From what I've seen it looks ok, but we probably want to walk through some courses and see if there's anything unusual.

<img width="1195" height="715" alt="image" src="https://github.com/user-attachments/assets/18787309-c8b1-4809-a10e-023314d9a53d" />
