### PR TITLE
fix timing issue when injecting offline videos

### DIFF
--- a/src/course/inject_offline_videos.ts
+++ b/src/course/inject_offline_videos.ts
@@ -11,7 +11,7 @@ export default function injectOfflineVideos() {
 
   document
     .querySelectorAll<HTMLElement>(
-      ".video-player-wrapper .video-container div[data-setup*='youtube.com']",
+      ".video-player-wrapper .video-container [data-setup*='youtube.com']",
     )
     .forEach((videoPlayer) => {
       if (!videoPlayer) return;


### PR DESCRIPTION
The element we query for starts a video and is replaced with a div by another script. Sometimes our script would run first and not detect the element. The query now does not specify an element type.

Fixes #130 